### PR TITLE
Include endpoint in trigger data

### DIFF
--- a/lib/bucket_files.js
+++ b/lib/bucket_files.js
@@ -4,6 +4,7 @@ const errors = require('./errors.js')
 
 module.exports = (client, bucket, logger) => {
   const lookup = files => new Map(files.map(file => [ file.Key, file ]))
+  const endpoint = client.config.endpoint
 
   const file_changes = (previous, current) => {
     const changes = []
@@ -11,17 +12,17 @@ module.exports = (client, bucket, logger) => {
 
     for (let file of current) { 
       if (!by_key.has(file.Key)) {
-        changes.push({ status: 'added', bucket: bucket, file })
+        changes.push({ status: 'added', bucket: bucket, endpoint: endpoint, file })
       } else {
         if (by_key.get(file.Key).ETag !== file.ETag) {
-          changes.push({ status: 'modified', bucket: bucket, file })
+          changes.push({ status: 'modified', bucket: bucket, endpoint: endpoint, file })
         }
         by_key.delete(file.Key)
       } 
     }
 
     for (let [ name, file ] of by_key) { 
-      changes.push({ status: 'deleted', bucket: bucket, file })
+      changes.push({ status: 'deleted', bucket: bucket, endpoint: endpoint, file })
     }
 
     return changes

--- a/test/unit/bucket_files.test.js
+++ b/test/unit/bucket_files.test.js
@@ -2,9 +2,18 @@ import test from 'ava'
 const crypto = require("crypto")
 const BucketFiles = require('../../lib/bucket_files.js')
 
-const client = () => {}
 const bucket = 'some-bucket'
+const test_endpoint = 'https://s3.eu-gb.cloud-object-storage.appdomain.cloud'
 const logger = { debug: () => {}, info: () => {} }
+const client = {
+  config: {
+    endpoint: test_endpoint
+  },
+  listObjects: options => {
+    t.is(options.Bucket, bucket)
+    return { promise: () => Promise.resolve(results) }
+  }
+}
 
 test('should return no changes for empty current and previous buckets', t => {
   const changed = BucketFiles(client, bucket, logger).file_changes([], [])
@@ -199,6 +208,9 @@ test('should return empty array for empty bucket', async t => {
   const results = { Contents: [] }
 
   const client = {
+    config: {
+      endpoint: test_endpoint
+    },
     listObjects: options => {
       t.is(options.Bucket, bucket)
       return { promise: () => Promise.resolve(results) }
@@ -218,6 +230,9 @@ test('should return current bucket files', async t => {
   ] }
 
   const client = {
+    config: {
+      endpoint: test_endpoint
+    },
     listObjects: options => {
       t.is(options.Bucket, bucket)
       return { promise: () => Promise.resolve(results) }


### PR DESCRIPTION
the target openwhisk action that will process the event will likely need to know the endpoint associated with the file/object so the action can access the file/object and still be somewhat generic and not require the endpoint to be hardwired into the action as a predefined parameter.