### PR TITLE
Allow the default ibm auth endpoint to be overridden

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,9 +27,10 @@ module.exports = function (triggerManager, logger, redis = process.env.REDIS) {
       remove(id)
     }
 
-    const { bucket, interval, s3_endpoint, s3_apikey } = details
+    const { bucket, interval, s3_endpoint, s3_apikey, auth_endpoint } = details
 
-    const client = new COS.S3({ endpoint: s3_endpoint, apiKeyId: s3_apikey })
+    // When `auth_endpoint` is not defined, the COS provided default 'https://iam.ng.bluemix.net/oidc/token' is used
+    const client = new COS.S3({ endpoint: s3_endpoint, apiKeyId: s3_apikey, ibmAuthEndpoint: auth_endpoint })
 
     const bucketFiles = BucketFiles(client, bucket, logger)
     const bucketEventQueue = Queue(id)


### PR DESCRIPTION
- current cos sdk default is `'https://iam.ng.bluemix.net/oidc/token'`, but that could change
https://github.com/IBM/ibm-cos-sdk-js/blob/9a0b08a6b8d744354c046f3c69d6bc820bf18e21/lib/iam/token_manager.js#L77