### PR TITLE
Adding support for more than 1,000 COS Objects

### DIFF
--- a/lib/bucket_files.js
+++ b/lib/bucket_files.js
@@ -53,8 +53,7 @@ module.exports = (client, bucket, logger) => {
         logger.info(`listObjects returned ${objectsRead.length} for bucket: ${bucket}`)
         return objectsRead
     } catch (err) {
-        //logger.debug(`listObjects returned error`, err)
-        console.error(err);
+        logger.debug(`listObjects returned error`, err)
         const message = errors.format(err)
         throw new Error(message)
     }

--- a/lib/bucket_files.js
+++ b/lib/bucket_files.js
@@ -30,15 +30,33 @@ module.exports = (client, bucket, logger) => {
 
   const current = async () => {
     try {
-      logger.info(`executing listObjects for bucket: ${bucket}`)
-      const results = await client.listObjects({ Bucket: bucket }).promise()
-      logger.debug(`listObjects response for bucket: ${bucket}`, results)
-      logger.info(`listObjects returned ${results.Contents.length} for bucket: ${bucket}`)
-      return results.Contents
+        var params = { Bucket: bucket };
+        var allObjectsRead = false;
+        var objectsRead = new Array();
+        logger.info(`executing listObjects for bucket: ${bucket}`);
+        while (!allObjectsRead) {
+            var results = await client.listObjectsV2(params).promise();
+            results.Contents.forEach(element => {
+                // Could delete non-essential properties from the data here
+                // For example: element.StorageClass = null ;
+                //
+                // Could lower the memory footprint by converting the Timestamp to UTC millis
+                //              element.LastModified = new Date(element.LastModified).getTime();
+                objectsRead.push(element);
+            });
+            if (results.IsTruncated)
+                params.ContinuationToken = results.NextContinuationToken;
+            else
+                allObjectsRead = true;
+        }
+        logger.debug(`listObjects response for bucket: ${bucket}`, results);
+        logger.info(`listObjects returned ${objectsRead.length} for bucket: ${bucket}`)
+        return objectsRead
     } catch (err) {
-      logger.debug(`listObjects returned error`, err)
-      const message = errors.format(err)
-      throw new Error(message)
+        //logger.debug(`listObjects returned error`, err)
+        console.error(err);
+        const message = errors.format(err)
+        throw new Error(message)
     }
   }
 


### PR DESCRIPTION
This change is to use the listObjectsV2 COS API which allows repeated calls to the API in order to retrieve all objects from a COS bucket regardless of file count.